### PR TITLE
Fix `Reader` ignoring last character of last sequence

### DIFF
--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -66,6 +66,10 @@ bool Reader::read_chains(ChainSet& dst, size_t max_bytes) {
                 bytes_over = 0;
                 is_name = true;
 
+                if (c != '>') {
+                    data[data_length++] = c;
+                }
+
                 dst.emplace_back(createChain(num_chains_read_++, name, name_length,
                     data, data_length));
 


### PR DESCRIPTION
Hi @rvaser!

I started making a Python wrapper for SWORD ([althonos/pyswrd](https://github.com/althonos/pyswrd)) and while checking out the code and generating results to use in tests I noticed that SWORD was reporting scores different from the CLI Opal despite using the same sequences. I tracked down the bug and found out that the `Reader` is ignoring the last character of the last sequence.